### PR TITLE
Add configuration error for markdownextradata before table-reader, closes #20

### DIFF
--- a/mkdocs_table_reader_plugin/plugin.py
+++ b/mkdocs_table_reader_plugin/plugin.py
@@ -116,7 +116,7 @@ class TableReaderPlugin(BasePlugin):
             # match group 0: to extract any leading whitespace 
             # match group 1: to extract the arguments (positional and keywords)
             tag_pattern = re.compile(
-                "( *)\{\{ %s\((.+)\) \}\}" % reader, flags=re.IGNORECASE
+                "( *)\{\{\s+%s\((.+)\)\s+\}\}" % reader, flags=re.IGNORECASE
             )
 
             matches = re.findall(tag_pattern, markdown)

--- a/tests/fixtures/basic_setup/docs/bad_tags.md
+++ b/tests/fixtures/basic_setup/docs/bad_tags.md
@@ -8,9 +8,6 @@ some badly formatted tags:
 
 {{ read_csv() }}
 
-## Strange and wrong characters
-
-{{ read\_csv('path') }}
 
 ## No proper spaces
 

--- a/tests/fixtures/basic_setup/mkdocs.yml
+++ b/tests/fixtures/basic_setup/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: test git_table_reader site
-use_directory_urls: true
+use_directory_urls: false
 
 plugins:
     - search

--- a/tests/fixtures/basic_setup/mkdocs_w_markdownextradata.yml
+++ b/tests/fixtures/basic_setup/mkdocs_w_markdownextradata.yml
@@ -1,7 +1,0 @@
-site_name: test git_table_reader site
-use_directory_urls: true
-
-plugins:
-    - search
-    - table-reader
-    - markdownextradata

--- a/tests/fixtures/basic_setup/mkdocs_w_markdownextradata_wrong_order.yml
+++ b/tests/fixtures/basic_setup/mkdocs_w_markdownextradata_wrong_order.yml
@@ -1,7 +1,0 @@
-site_name: test git_table_reader site
-use_directory_urls: true
-
-plugins:
-    - search
-    - markdownextradata
-    - table-reader

--- a/tests/fixtures/datapathproject/mkdocs.yml
+++ b/tests/fixtures/datapathproject/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: test git_table_reader site
-use_directory_urls: true
+use_directory_urls: false
 
 plugins:
     - search

--- a/tests/fixtures/datapathproject/mkdocs_trailingslash.yml
+++ b/tests/fixtures/datapathproject/mkdocs_trailingslash.yml
@@ -1,5 +1,5 @@
 site_name: test git_table_reader site
-use_directory_urls: true
+use_directory_urls: false
 
 plugins:
     - search

--- a/tests/fixtures/markdownextradata/mkdocs_w_markdownextradata.yml
+++ b/tests/fixtures/markdownextradata/mkdocs_w_markdownextradata.yml
@@ -1,0 +1,13 @@
+site_name: test git_table_reader site
+use_directory_urls: true
+
+plugins:
+    - search
+    - table-reader
+    - markdownextradata
+
+extra:
+    customer:
+        name: Your name here
+        web: www.example.com
+        salt: salt.example.com

--- a/tests/fixtures/markdownextradata/mkdocs_w_markdownextradata_wrong_order.yml
+++ b/tests/fixtures/markdownextradata/mkdocs_w_markdownextradata_wrong_order.yml
@@ -1,0 +1,13 @@
+site_name: test git_table_reader site
+use_directory_urls: true
+
+plugins:
+    - search
+    - markdownextradata
+    - table-reader
+
+extra:
+    customer:
+        name: Your name here
+        web: www.example.com
+        salt: salt.example.com

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -179,7 +179,7 @@ def test_compatibility_markdownextradata(tmp_path):
     assert re.search(r"www.example.com", contents)
 
     tmp_proj = setup_clean_mkdocs_folder(
-        "tests/fixtures/basic_setup/mkdocs_w_markdownextradata_wrong_order.yml", tmp_path
+        "tests/fixtures/markdownextradata/mkdocs_w_markdownextradata_wrong_order.yml", tmp_path
     )
 
     result = build_docs_setup(tmp_proj)
@@ -193,7 +193,7 @@ def test_compatibility_markdownextradata(tmp_path):
 
     # With correct order, no error
     tmp_proj = setup_clean_mkdocs_folder(
-        "tests/fixtures/basic_setup/mkdocs_w_markdownextradata.yml", tmp_path
+        "tests/fixtures/markdownextradata/mkdocs_w_markdownextradata.yml", tmp_path
     )
 
     result = build_docs_setup(tmp_proj)


### PR DESCRIPTION
Added ConfigurationError for wrong plugin order, similar to the [resolve](https://github.com/timvink/mkdocs-table-reader-plugin/commit/1d7e477673a2cc1af9fd686d7c96623a65637835) for #14