### PR TITLE
Allow paths relative to page

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -37,3 +37,30 @@ The value is a string, one of `docs_dir` or `config_dir`. The default is `config
 - `config_dir`: the directory where your project's `mkdocs.yml` file is located.
 - `docs_dir`: the directory where your projects' `docs/` folder is located.
 
+
+#### `search_page_directory`
+
+Default: `True`. When enabled, if a path is not found in `data_path`/
+`base_path`, also search relative to the current page's directory. Note that
+even when True, the data path is searched first (i.e. relative to `data_path`),
+and if a file is not found there, then the page's directory is searched.
+
+This enables e.g.:
+
+```
+$ tree
+.
+├── docs
+│   └── b
+│       ├── basic_table.csv
+│       └── index.md
+└── mkdocs.yml
+$ cat docs/b/index.md
+# test
+
+<!-- note that basic_table.csv is relative to docs/b/ -->
+{{ read_tsv("basic_table.csv") }}
+
+<!-- If search_page_directory is False, one needs to use -->
+{{ read_tsv("docs/b/basic_table.csv") }}
+```

--- a/mkdocs_table_reader_plugin/plugin.py
+++ b/mkdocs_table_reader_plugin/plugin.py
@@ -196,19 +196,25 @@ class TableReaderPlugin(BasePlugin):
                 # Safely parse the arguments
                 pd_args, pd_kwargs = parse_argkwarg(result[1])
 
-                # Make sure the path is relative to "data_path"
-                if len(pd_args) > 0:
-                    pd_args[0] = os.path.join(self.config.get("data_path"), pd_args[0])
-                    file_path = pd_args[0]
-
-                if pd_kwargs.get("filepath_or_buffer"):
-                    file_path = pd_kwargs["filepath_or_buffer"]
-                    file_path = os.path.join(self.config.get("data_path"), file_path)
-                    pd_kwargs["filepath_or_buffer"] = file_path
-
                 # Load the table
                 with cd(mkdocs_dir):
-                    if not os.path.exists(file_path):
+                    pagedir = os.path.dirname(page.file.abs_src_path)
+                    datadir = self.config.get("data_path")
+                    for data_path in [datadir, pagedir]:
+                        # Make sure the path is relative to "data_path"
+                        if len(pd_args) > 0:
+                            pd_args[0] = os.path.join(data_path, pd_args[0])
+                            file_path = pd_args[0]
+
+                        if pd_kwargs.get("filepath_or_buffer"):
+                            file_path = pd_kwargs["filepath_or_buffer"]
+                            file_path = os.path.join(data_path, file_path)
+                            pd_kwargs["filepath_or_buffer"] = file_path
+                        print("try", file_path)
+                        if os.path.exists(file_path):
+                            print("found", file_path)
+                            break
+                    else:
                         raise FileNotFoundError(
                             "[table-reader-plugin]: File does not exist: %s" % file_path
                         )


### PR DESCRIPTION
Hello, and thanks for a neat plugin.

The attached patch allows paths to be specified relative to a page's source. For example:

```
$ tree
.
└── a
    └── b
        └── c
            ├── index.md
            └── table.csv
$ cat a/b/c/index.md 
# test

{{ read_tsv("table.csv") }}
````

Specifically, we check if the file is in the configured data path, and iff not found there, check relative to the page's source directory.

