### PR TITLE
Create schema.json file

### DIFF
--- a/docs/schema.json
+++ b/docs/schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "title": "MkDocs plugin that enables a markdown tag like {{ read_csv('table.csv') }} to directly insert various table formats into a page.",
+  "oneOf": [
+    {
+      "markdownDescription": "https://timvink.github.io/mkdocs-table-reader-plugin/",
+      "enum": ["table-reader"]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "table-reader": {
+          "markdownDescription": "https://timvink.github.io/mkdocs-table-reader-plugin/options/",
+          "type": "object",
+          "properties": {
+            "base_path": {
+              "title": "The base path where mkdocs-table-reader-plugin will search for input files. The path to your table files should be relative to the base_path.",
+              "markdownDescription": "https://timvink.github.io/mkdocs-table-reader-plugin/options/#base_path",
+              "type": "string",
+              "enum": ["config_dir", "docs_dir"],
+              "default": "config_dir"
+            },
+            "data_path": {
+              "title": "The path to your table files should be relative to the base_path. If you use a folder for all your table files you can shorten the path specification by setting the data_path.",
+              "markdownDescription": "https://timvink.github.io/mkdocs-table-reader-plugin/options/#data_path",
+              "type": "string",
+              "default": "."
+            },
+            "search_page_directory": {
+              "title": "When enabled, if a filepath is not found, the plugin will also attempt to find the file relative to the current page's directory.",
+              "markdownDescription": "https://timvink.github.io/mkdocs-table-reader-plugin/options/#search_page_directory",
+              "type": "boolean",
+              "default": true
+            },
+            "allow_missing_files": {
+              "title": "When enabled, if a filepath is not found, the plugin will raise a warning instead of an error.",
+              "markdownDescription": "https://timvink.github.io/mkdocs-table-reader-plugin/options/#allow_missing_files",
+              "type": "boolean",
+              "default": false
+            },
+            "select_readers": {
+              "title": "Specify a list of reader to improve documentation build times for large sites.",
+              "markdownDescription": "https://timvink.github.io/mkdocs-table-reader-plugin/options/#select_readers",
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "const": "read_csv",
+                    "title": "{{ read_csv() }} passed to pandas.read_csv()",
+                    "description": "https://timvink.github.io/mkdocs-table-reader-plugin/readers/#read_csv"
+                  },
+                  {
+                    "const": "read_fwf",
+                    "title": "{{ read_fwf() }} passed to pandas.read_fwf()",
+                    "description": "https://timvink.github.io/mkdocs-table-reader-plugin/readers/#read_fwf"
+                  },
+                  {
+                    "const": "read_yaml",
+                    "title": "{{ read_yaml() }} is parsed with yaml.safe_load() and passed to pandas.json_normalize()",
+                    "description": "https://timvink.github.io/mkdocs-table-reader-plugin/readers/#read_yaml"
+                  },
+                  {
+                    "const": "read_table",
+                    "title": "{{ read_table() }} passed to pandas.read_table()",
+                    "description": "https://timvink.github.io/mkdocs-table-reader-plugin/readers/#read_table"
+                  },
+                  {
+                    "const": "read_json",
+                    "title": "{{ read_json() }} passed to pandas.read_json()",
+                    "description": "https://timvink.github.io/mkdocs-table-reader-plugin/readers/#read_json"
+                  },
+                  {
+                    "const": "read_feather",
+                    "title": "{{ read_feather() }} passed to pandas.read_feather()",
+                    "description": "https://timvink.github.io/mkdocs-table-reader-plugin/readers/#read_feather"
+                  },
+                  {
+                    "const": "read_excel",
+                    "title": "{{ read_excel() }} passed to pandas.read_excel()",
+                    "description": "https://timvink.github.io/mkdocs-table-reader-plugin/readers/#read_excel"
+                  },
+                  {
+                    "const": "read_raw",
+                    "title": "{{ read_raw() }} inserts contents from a file directly. This is great if you have a file with a table already in markdown format. It could also replace a workflow where you use the snippets extension to embed external files.",
+                    "description": "https://timvink.github.io/mkdocs-table-reader-plugin/readers/#read_raw"
+                  }
+                ]
+              },
+              "default": [
+                "read_csv",
+                "read_fwf",
+                "read_yaml",
+                "read_table",
+                "read_json",
+                "read_feather",
+                "read_excel",
+                "read_raw"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}


### PR DESCRIPTION
### Description

Using the following resources as a reference, I created a schema.json file:

- https://timvink.github.io/mkdocs-table-reader-plugin/options/
- https://timvink.github.io/mkdocs-table-reader-plugin/readers/

I followed the patterns of the `schema.json` files of other mkdocs plugins that [mkdocs-material](https://github.com/squidfunk/mkdocs-material) references:
https://github.com/squidfunk/mkdocs-material/blob/master/docs/schema/plugins.json

### Background

`mkdocs-material`'s linter throws a `Value is not accepted.` when defining `table-reader` as a `plugin` in a project's `mkdocs.yml` file. A similar issue has been brought up in [the past](https://github.com/squidfunk/mkdocs-material/pull/6381)., so I'm following the precedent. I intended to create a PR in the `mkdocs-material` repo including this file as a reference in their plugin schema.

As an aside, sorry in advance if I'm missing anything obvious; this tech is new to me. 